### PR TITLE
Add Dockerfiles for API and Worker

### DIFF
--- a/backend/WIB.API/Dockerfile
+++ b/backend/WIB.API/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore WIB.API/WIB.API.csproj
+RUN dotnet publish WIB.API/WIB.API.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "WIB.API.dll"]
+

--- a/backend/WIB.Worker/Dockerfile
+++ b/backend/WIB.Worker/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore WIB.Worker/WIB.Worker.csproj
+RUN dotnet publish WIB.Worker/WIB.Worker.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "WIB.Worker.dll"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   api:
-    build: ./backend/WIB.API
+    build:
+      context: ./backend
+      dockerfile: WIB.API/Dockerfile
     environment:
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__Default: Host=db;Database=wib;Username=wib;Password=wib
@@ -21,7 +23,9 @@ services:
       - ml
       - qdrant
   worker:
-    build: ./backend/WIB.Worker
+    build:
+      context: ./backend
+      dockerfile: WIB.Worker/Dockerfile
     environment:
       ConnectionStrings__Default: Host=db;Database=wib;Username=wib;Password=wib
       Minio__Endpoint: minio:9000


### PR DESCRIPTION
## Summary
- add Dockerfiles for API and background worker
- adjust docker-compose to build API and Worker from backend context

## Testing
- `dotnet test backend/WIB.Tests/WIB.Tests.csproj`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c550d82b60832d9f7d8fd33424f150