### PR TITLE
Add frontend service with environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,3 +77,19 @@ services:
     image: qdrant/qdrant:latest
     ports:
       - "6333:6333"
+  frontend:
+    build: ./frontend
+    environment:
+      API_URL: http://api:8080
+      OCR_URL: http://ocr:8081
+      ML_URL: http://ml:8082
+      QDRANT_URL: http://qdrant:6333
+      MINIO_URL: http://minio:9000
+    ports:
+      - "4200:80"
+    depends_on:
+      - api
+      - ocr
+      - ml
+      - qdrant
+      - minio

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM nginx:alpine
+
+# Install envsubst and bash
+RUN apk add --no-cache bash gettext
+
+# Copy application files
+COPY apps/wib-wmc/src/ /usr/share/nginx/html/
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/apps/wib-wmc/src/app/env.service.ts
+++ b/frontend/apps/wib-wmc/src/app/env.service.ts
@@ -1,9 +1,26 @@
 import { Injectable } from '@angular/core';
 
-export interface EnvConfig { apiUrl: string; }
+export interface EnvConfig {
+  apiUrl: string;
+  ocrUrl: string;
+  mlUrl: string;
+  qdrantUrl: string;
+  minioUrl: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class EnvService {
-  private cfg: EnvConfig = (window as any).__env || { apiUrl: '' };
+  private cfg: EnvConfig = (window as any).__env || {
+    apiUrl: '',
+    ocrUrl: '',
+    mlUrl: '',
+    qdrantUrl: '',
+    minioUrl: ''
+  };
+
   get apiUrl(): string { return this.cfg.apiUrl; }
+  get ocrUrl(): string { return this.cfg.ocrUrl; }
+  get mlUrl(): string { return this.cfg.mlUrl; }
+  get qdrantUrl(): string { return this.cfg.qdrantUrl; }
+  get minioUrl(): string { return this.cfg.minioUrl; }
 }

--- a/frontend/apps/wib-wmc/src/index.html
+++ b/frontend/apps/wib-wmc/src/index.html
@@ -6,6 +6,14 @@
   </head>
   <body>
     <wib-wmc-root></wib-wmc-root>
-    <script>window.__env={apiUrl:''};</script>
+    <script>
+      window.__env = {
+        apiUrl: "${API_URL}",
+        ocrUrl: "${OCR_URL}",
+        mlUrl: "${ML_URL}",
+        qdrantUrl: "${QDRANT_URL}",
+        minioUrl: "${MINIO_URL}"
+      };
+    </script>
   </body>
 </html>

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# Replace env vars in index.html
+envsubst < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
+mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+# Start nginx
+exec "$@"


### PR DESCRIPTION
## Summary
- add nginx-based Dockerfile and entrypoint for frontend
- expose API and service endpoints via docker-compose environment variables
- read service URLs from injected env vars in frontend

## Testing
- `npm run lint:all`
- `docker build -t wib-frontend-test ./frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c559cf64a4832d8cd1749c9a1d3aa4