### PR TITLE
feat(frontend): add wmc and devices frontends

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,11 @@ services:
     image: qdrant/qdrant:latest
     ports:
       - "6333:6333"
-  frontend:
-    build: ./frontend
+  wib-wmc:
+    build:
+      context: ./frontend
+      args:
+        APP_PATH: apps/wib-wmc
     environment:
       API_URL: http://api:8080
       OCR_URL: http://ocr:8081
@@ -93,3 +96,14 @@ services:
       - ml
       - qdrant
       - minio
+  wib-devices:
+    build:
+      context: ./frontend
+      args:
+        APP_PATH: apps/wib-devices
+    environment:
+      API_URL: http://api:8080
+    ports:
+      - "4201:80"
+    depends_on:
+      - api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,8 +3,11 @@ FROM nginx:alpine
 # Install envsubst and bash
 RUN apk add --no-cache bash gettext
 
+# Select which app to serve (default: wib-wmc)
+ARG APP_PATH=apps/wib-wmc
+
 # Copy application files
-COPY apps/wib-wmc/src/ /usr/share/nginx/html/
+COPY ${APP_PATH}/src/ /usr/share/nginx/html/
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/frontend/apps/wib-devices/src/index.html
+++ b/frontend/apps/wib-devices/src/index.html
@@ -6,6 +6,10 @@
   </head>
   <body>
     <wib-devices-root></wib-devices-root>
-    <script>window.__env={apiUrl:''};</script>
+    <script>
+      window.__env = {
+        apiUrl: "${API_URL}"
+      };
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- support selecting frontend app via build argument
- add wib-wmc and wib-devices services to docker compose
- configure devices index.html to read API_URL at runtime

## Testing
- `npm run lint:all`
- `npm run check:angular`


------
https://chatgpt.com/codex/tasks/task_e_68c55cdacaa8832d972fa595c2403b55